### PR TITLE
envsetup: Automatically set CCACHE_EXEC to the system's ccache

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1619,6 +1619,17 @@ validate_current_shell
 source_vendorsetup
 addcompletions
 
+# check and set ccache path on envsetup
+if [ -z ${CCACHE_EXEC} ]; then
+    ccache_path=$(which ccache)
+    if [ ! -z "$ccache_path" ]; then
+        export CCACHE_EXEC="$ccache_path"
+        echo "ccache found and CCACHE_EXEC has been set to : $ccache_path"
+    else
+        echo "ccache not found/installed!"
+    fi
+fi
+
 export ANDROID_BUILD_TOP=$(gettop)
 
 . $ANDROID_BUILD_TOP/vendor/exthm/build/envsetup.sh


### PR DESCRIPTION
* check for ccache tool and set its path in CCACHE_EXEC if it hasn't been set already

Change-Id: Ife9d0a723cb90b89392ee288ebe6e7e9f2be7eef